### PR TITLE
Fix: Turbo and stream false convert data wrong

### DIFF
--- a/lib/src/repository/text_completions_repository.dart
+++ b/lib/src/repository/text_completions_repository.dart
@@ -101,11 +101,16 @@ class TextCompletionsRepository extends TextCompletionsRepositoryInterface {
         );
       }
 
-      responseText = (response.data['choices'][0]['message']['content'] ?? '')
-          .toString()
-          .trim();
+      if (params.isTurbo) {
+        responseText =
+            (response.data['choices'][0]?['message']?['content'] ?? '')
+                .toString()
+                .trim();
+      } else {
+        responseText =
+            (response.data['choices'][0]?['text'] ?? '').toString().trim();
+      }
     }
-
     return responseText;
   }
 


### PR DESCRIPTION
_ When setting stream == false and model GPT != gpt3 5 turbo, convert data returns error _

## Pre-launch Checklist

- [x] I read the rules PR (title, labels, commit messages...).
- [x] I definitely don't PR files with pointless edits.
- [x] I added screenshots if change UI/UX (has modified code in lib/src/ui/*).
- [x] I wrote all test cases coverage and all passed.
- [x] All existing and new tests are passing.

## Testcases covered (check if passed)

- [x] Set stream false -> Model GPT == curie -> Enter question -> Send request -> Get response -> Return answer of chat GPT